### PR TITLE
chore: Revert "feat!: migrate to constructs v10 (#78)"

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -25,7 +25,6 @@
     },
     {
       "name": "constructs",
-      "version": "10.0.0",
       "type": "build"
     },
     {
@@ -102,7 +101,6 @@
     },
     {
       "name": "constructs",
-      "version": "^10",
       "type": "peer"
     }
   ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -17,7 +17,7 @@ const project = new cdk.JsiiProject({
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   peerDeps: [
     'cdk8s',
-    'constructs@^10',
+    'constructs',
   ],
 
   publishToMaven: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "cdk8s": "1.3.0",
-    "constructs": "10.0.0",
+    "constructs": "3.3.166",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.5.0",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "cdk8s": "^1.3.0",
-    "constructs": "^10"
+    "constructs": "^3.3.166"
   },
   "bundledDependencies": [],
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,10 +1535,10 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.0.tgz#a6d498540111f6d75663711d0fa65f32fc8f1786"
-  integrity sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==
+constructs@3.3.166:
+  version "3.3.166"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.166.tgz#0d8ff31366cbe3c15df6f7aeba15b4d5e81f0087"
+  integrity sha512-vhFswEqFb5BRkeYbWPd66A+BtvSSSdRI/1TYNwetC2reJul+ztI40vK9l2CNx1Vi/EOAQp1qjjjTEg+29irtYA==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"


### PR DESCRIPTION
This reverts commit 09602a475d5261df111f5469f18a17e0850ab66a.

Related to https://github.com/cdk8s-team/cdk8s-core/pull/154

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>