### PR TITLE
fix: Remove name to fix unknown field name on synth

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -129,7 +129,6 @@ export class Dashboard extends Construct {
           ...defaults,
           ...props.jsonModel,
         }, null, 2),
-        name: id,
       },
     });
 

--- a/test/__snapshots__/grafana.test.ts.snap
+++ b/test/__snapshots__/grafana.test.ts.snap
@@ -135,7 +135,6 @@ Array [
   \\"version\\": 0,
   \\"links\\": []
 }",
-      "name": "my-dashboard",
       "plugins": Array [],
     },
   },
@@ -286,7 +285,6 @@ Array [
     }
   ]
 }",
-      "name": "my-dashboard",
       "plugins": Array [],
     },
   },
@@ -463,7 +461,6 @@ Array [
   \\"version\\": 0,
   \\"links\\": []
 }",
-      "name": "my-dashboard",
       "plugins": Array [],
     },
   },


### PR DESCRIPTION
[Fixes # 92](https://github.com/cdk8s-team/cdk8s-grafana/issues/92)

Original error message:

> error: error validating "dist/GrafanaDashboard.grafana-k8sdashboard-c8f7fb82.k8s.yaml": error validating data: ValidationError(GrafanaDashboard.spec): unknown field "name" in org.integreatly.v1alpha1.GrafanaDashboard.spec; if you choose to ignore these errors, turn validation off with --validate=false

Fix: remove the name attribute within the spec

See details on issue