### PR TITLE
feat: customize service type

### DIFF
--- a/API.md
+++ b/API.md
@@ -568,6 +568,19 @@ Require login in order to view or manage dashboards.
 
 ---
 
+##### `serviceType`<sup>Optional</sup> <a name="cdk8s-grafana.GrafanaProps.property.serviceType"></a>
+
+```typescript
+public readonly serviceType: string;
+```
+
+- *Type:* `string`
+- *Default:* ClusterIP
+
+Type of service to be created (NodePort, ClusterIP or LoadBalancer).
+
+---
+
 
 
 ## Enums <a name="Enums"></a>

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -129,7 +129,6 @@ export class Dashboard extends Construct {
           ...defaults,
           ...props.jsonModel,
         }, null, 2),
-        name: id,
       },
     });
 

--- a/src/grafana.ts
+++ b/src/grafana.ts
@@ -18,6 +18,12 @@ export interface GrafanaProps {
   readonly ingress?: boolean;
 
   /**
+   * Type of service to be created (NodePort, ClusterIP or LoadBalancer)
+   * @default ClusterIP
+   */
+  readonly serviceType?: string;
+
+  /**
    * Default admin username.
    * @default "root"
    */
@@ -75,6 +81,7 @@ export class Grafana extends Construct {
 
     const baseImage = props.image ?? 'public.ecr.aws/ubuntu/grafana:latest';
     const ingress = props.ingress ?? true;
+    const serviceType = props.serviceType ?? 'ClusterIP';
     const adminUser = props.adminUser ?? 'root';
     const adminPassword = props.adminPassword ?? 'secret';
     const requireLogin = props.requireLogin ?? false;
@@ -89,6 +96,9 @@ export class Grafana extends Construct {
         baseImage: baseImage,
         ingress: {
           enabled: ingress,
+        },
+        service: {
+          type: serviceType,
         },
         client: {
           // without this, dashboards may not be automatically discovered

--- a/test/__snapshots__/grafana.test.ts.snap
+++ b/test/__snapshots__/grafana.test.ts.snap
@@ -135,7 +135,6 @@ Array [
   \\"version\\": 0,
   \\"links\\": []
 }",
-      "name": "my-dashboard",
       "plugins": Array [],
     },
   },
@@ -286,7 +285,6 @@ Array [
     }
   ]
 }",
-      "name": "my-dashboard",
       "plugins": Array [],
     },
   },
@@ -463,7 +461,6 @@ Array [
   \\"version\\": 0,
   \\"links\\": []
 }",
-      "name": "my-dashboard",
       "plugins": Array [],
     },
   },

--- a/test/__snapshots__/grafana.test.ts.snap
+++ b/test/__snapshots__/grafana.test.ts.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`a grafana instance Nodeport and no ingress 1`] = `
+Array [
+  Object {
+    "apiVersion": "integreatly.org/v1alpha1",
+    "kind": "Grafana",
+    "metadata": Object {
+      "labels": Object {
+        "app": "grafana",
+      },
+      "name": "test-my-grafana-c8153986",
+    },
+    "spec": Object {
+      "baseImage": "public.ecr.aws/ubuntu/grafana:latest",
+      "client": Object {
+        "preferService": true,
+      },
+      "config": Object {
+        "auth.anonymous": Object {
+          "enabled": true,
+        },
+        "log": Object {
+          "level": "info",
+          "mode": "console",
+        },
+        "security": Object {
+          "admin_password": "secret",
+          "admin_user": "root",
+        },
+      },
+      "dashboardLabelSelector": Array [
+        Object {
+          "matchLabels": Object {
+            "app": "grafana",
+          },
+        },
+      ],
+      "deployment": Object {
+        "labels": Object {
+          "app": "grafana",
+        },
+      },
+      "ingress": Object {
+        "enabled": false,
+      },
+      "service": Object {
+        "type": "NodePort",
+      },
+    },
+  },
+]
+`;
+
 exports[`a grafana instance defaults 1`] = `
 Array [
   Object {
@@ -43,6 +95,9 @@ Array [
       },
       "ingress": Object {
         "enabled": true,
+      },
+      "service": Object {
+        "type": "ClusterIP",
       },
     },
   },
@@ -92,6 +147,9 @@ Array [
       },
       "ingress": Object {
         "enabled": true,
+      },
+      "service": Object {
+        "type": "ClusterIP",
       },
     },
   },
@@ -205,6 +263,9 @@ Array [
       },
       "ingress": Object {
         "enabled": true,
+      },
+      "service": Object {
+        "type": "ClusterIP",
       },
     },
   },
@@ -335,6 +396,9 @@ Array [
       "ingress": Object {
         "enabled": true,
       },
+      "service": Object {
+        "type": "ClusterIP",
+      },
     },
   },
 ]
@@ -383,6 +447,9 @@ Array [
       },
       "ingress": Object {
         "enabled": true,
+      },
+      "service": Object {
+        "type": "ClusterIP",
       },
     },
   },

--- a/test/grafana.test.ts
+++ b/test/grafana.test.ts
@@ -25,6 +25,24 @@ describe('a grafana instance', () => {
     expect(Testing.synth(chart)).toMatchSnapshot();
   });
 
+  test('Nodeport and no ingress', () => {
+    // GIVEN
+    const app = Testing.app();
+    const chart = new Chart(app, 'test');
+
+    // WHEN
+    new Grafana(chart, 'my-grafana', {
+      ingress: false,
+      serviceType: 'NodePort',
+    });
+
+    // THEN
+    const manifest = Testing.synth(chart);
+    expect(manifest).toMatchSnapshot();
+    expect(manifest[0].spec.ingress.enabled).toEqual(false);
+    expect(manifest[0].spec.service.type).toEqual('NodePort');
+  });
+
   test('with customized auth', () => {
     // GIVEN
     const app = Testing.app();


### PR DESCRIPTION
[Fixes #93 ](https://github.com/cdk8s-team/cdk8s-grafana/issues/93)

Exposes service type so that end user can expose Grafana using a NodePort. Currently the service was always created as a ClusterIP

