### PR TITLE
chore: add common projen config

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,6 +1,10 @@
 {
   "dependencies": [
     {
+      "name": "@cdk8s/projen-common",
+      "type": "build"
+    },
+    {
       "name": "@types/jest",
       "type": "build"
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,6 @@
-const { cdk, javascript } = require('projen');
+const { cdk } = require('projen');
+const { Cdk8sCommon } = require('@cdk8s/projen-common');
+
 const project = new cdk.JsiiProject({
   name: 'cdk8s-grafana',
   description: 'Grafana construct for cdk8s.',
@@ -18,6 +20,10 @@ const project = new cdk.JsiiProject({
   peerDeps: [
     'cdk8s',
     'constructs',
+  ],
+
+  devDeps: [
+    '@cdk8s/projen-common'
   ],
 
   publishToMaven: {
@@ -42,14 +48,13 @@ const project = new cdk.JsiiProject({
   },
   autoApproveUpgrades: true,
 
-  // run upgrade-dependencies workflow at a different hour than other cdk8s
-  // repos to decrease flakiness of integration tests caused by new versions of
-  // cdk8s being published to different languages at the same time
   depsUpgradeOptions: {
     workflowOptions: {
-      schedule: javascript.UpgradeDependenciesSchedule.expressions(['0 1 * * *']),
+      schedule: Cdk8sCommon.upgradeScheduleFor('cdk8s-grafana'),
     },
   },
 });
+
+new Cdk8sCommon(project);
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -2,6 +2,8 @@ const { Cdk8sCommon } = require('@cdk8s/projen-common');
 const { cdk } = require('projen');
 
 const project = new cdk.JsiiProject({
+  ...Cdk8sCommon.props,
+
   name: 'cdk8s-grafana',
   description: 'Grafana construct for cdk8s.',
   author: 'Amazon Web Services',
@@ -41,12 +43,6 @@ const project = new cdk.JsiiProject({
     dotNetNamespace: 'Org.Cdk8s.Grafana',
     packageId: 'Org.Cdk8s.Grafana',
   },
-
-  autoApproveOptions: {
-    allowedUsernames: ['cdk8s-automation'],
-    secret: 'GITHUB_TOKEN',
-  },
-  autoApproveUpgrades: true,
 
   depsUpgradeOptions: {
     workflowOptions: {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,5 +1,5 @@
-const { cdk } = require('projen');
 const { Cdk8sCommon } = require('@cdk8s/projen-common');
+const { cdk } = require('projen');
 
 const project = new cdk.JsiiProject({
   name: 'cdk8s-grafana',
@@ -23,7 +23,7 @@ const project = new cdk.JsiiProject({
   ],
 
   devDeps: [
-    '@cdk8s/projen-common'
+    '@cdk8s/projen-common',
   ],
 
   publishToMaven: {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "organization": false
   },
   "devDependencies": {
+    "@cdk8s/projen-common": "^0.0.2",
     "@types/jest": "^26.0.24",
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "organization": false
   },
   "devDependencies": {
-    "@cdk8s/projen-common": "^0.0.2",
+    "@cdk8s/projen-common": "^0.0.3",
     "@types/jest": "^26.0.24",
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,10 +285,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cdk8s/projen-common@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.2.tgz#506c0f2c513973a8c639eb28eb1b2422e7215ff9"
-  integrity sha512-T9E4jBD4DuIX3q7UtvXiNxI/DnlYv/rAerO5ctX+ckiW+42+HlA32ebtAUG2NOOKoiSMyrJpOC9O52rPffxNaA==
+"@cdk8s/projen-common@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.3.tgz#3260c6f18d095b2298fbdfb885fbba5d253a52dd"
+  integrity sha512-1/mR8v4cNGxs0A96KxqQJjtZwPuZOuRshM3F7CUbBG26AbYZpYU69zHlYcR21j/bzqHUa6wSwZ6dUInx2zu2JA==
 
 "@eslint/eslintrc@^1.2.2":
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,6 +285,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cdk8s/projen-common@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.2.tgz#506c0f2c513973a8c639eb28eb1b2422e7215ff9"
+  integrity sha512-T9E4jBD4DuIX3q7UtvXiNxI/DnlYv/rAerO5ctX+ckiW+42+HlA32ebtAUG2NOOKoiSMyrJpOC9O52rPffxNaA==
+
 "@eslint/eslintrc@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.2.tgz#4989b9e8c0216747ee7cca314ae73791bb281aae"


### PR DESCRIPTION
`new Cdk8sCommon(project)` doesn't actually do anything right now, but in the future if we want, we'll be able to easily add a file to all of the cdk8s repos. 🙂 

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>