### PR TITLE
chore: update projen project type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -85,7 +89,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -114,7 +118,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -139,7 +143,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -167,7 +171,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,3 +191,31 @@ jobs:
         run: cd .repo && npx projen package:dotnet
       - name: Collect dotnet Artifact
         run: mv .repo/dist dist
+  package-go:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "! needs.build.outputs.self_mutation_happened"
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,3 +215,40 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: npx -p publib@latest publib-nuget
+  release_golang:
+    name: Publish to GitHub Go Module Repository
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist
+      - name: Release
+        env:
+          GIT_BRANCH: main
+          GIT_USER_NAME: cdk8s-automation
+          GIT_USER_EMAIL: cdk8s-team@amazon.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
+        run: npx -p publib@latest publib-golang

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
         run: |-
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -51,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -80,7 +84,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -117,7 +121,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -152,7 +156,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -187,7 +191,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 2 * * *
+    - cron: 0 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,6 +10,7 @@ queue_rules:
       - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
+      - status-success=package-go
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
@@ -29,3 +30,4 @@ pull_request_rules:
       - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
+      - status-success=package-go

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -154,6 +154,9 @@
         },
         {
           "spawn": "package:dotnet"
+        },
+        {
+          "spawn": "package:go"
         }
       ]
     },
@@ -163,6 +166,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target dotnet"
+        }
+      ]
+    },
+    "package:go": {
+      "name": "package:go",
+      "description": "Create go language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target go"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -239,7 +239,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --updateSnapshot",
+          "exec": "jest --passWithNoTests --coverageProvider=v8 --updateSnapshot",
           "receiveArgs": true
         },
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,13 +1,9 @@
-const { Cdk8sCommon } = require('@cdk8s/projen-common');
-const { cdk } = require('projen');
+const { Cdk8sTeamJsiiProject } = require('@cdk8s/projen-common');
+const { javascript } = require('projen');
 
-const project = new cdk.JsiiProject({
-  ...Cdk8sCommon.props,
-
+const project = new Cdk8sTeamJsiiProject({
   name: 'cdk8s-grafana',
   description: 'Grafana construct for cdk8s.',
-  author: 'Amazon Web Services',
-  authorUrl: 'https://aws.amazon.com',
   keywords: [
     'kubernetes',
     'grafana',
@@ -15,10 +11,9 @@ const project = new cdk.JsiiProject({
     'dashboards',
     'observability',
   ],
-
   defaultReleaseBranch: 'main',
-  repositoryUrl: 'https://github.com/cdk8s-team/cdk8s-grafana.git',
-  projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
+  golang: false,
+
   peerDeps: [
     'cdk8s',
     'constructs',
@@ -28,29 +23,11 @@ const project = new cdk.JsiiProject({
     '@cdk8s/projen-common',
   ],
 
-  publishToMaven: {
-    javaPackage: 'org.cdk8s.grafana',
-    mavenGroupId: 'org.cdk8s',
-    mavenArtifactId: 'cdk8s-grafana',
-  },
-
-  publishToPypi: {
-    distName: 'cdk8s-grafana',
-    module: 'cdk8s_grafana',
-  },
-
-  publishToNuget: {
-    dotNetNamespace: 'Org.Cdk8s.Grafana',
-    packageId: 'Org.Cdk8s.Grafana',
-  },
-
   depsUpgradeOptions: {
     workflowOptions: {
-      schedule: Cdk8sCommon.upgradeScheduleFor('cdk8s-grafana'),
+      schedule: javascript.UpgradeDependenciesSchedule.expressions(['0 0 * * *']),
     },
   },
 });
-
-new Cdk8sCommon(project);
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,5 +1,4 @@
 const { Cdk8sTeamJsiiProject } = require('@cdk8s/projen-common');
-const { javascript } = require('projen');
 
 const project = new Cdk8sTeamJsiiProject({
   name: 'cdk8s-grafana',
@@ -12,22 +11,13 @@ const project = new Cdk8sTeamJsiiProject({
     'observability',
   ],
   defaultReleaseBranch: 'main',
-  golang: false,
-
   peerDeps: [
     'cdk8s',
     'constructs',
   ],
-
   devDeps: [
     '@cdk8s/projen-common',
   ],
-
-  depsUpgradeOptions: {
-    workflowOptions: {
-      schedule: javascript.UpgradeDependenciesSchedule.expressions(['0 0 * * *']),
-    },
-  },
 });
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "organization": false
   },
   "devDependencies": {
-    "@cdk8s/projen-common": "^0.0.237",
+    "@cdk8s/projen-common": "^0.0.244",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -72,6 +72,9 @@
     "kubernetes",
     "observability"
   ],
+  "engines": {
+    "node": ">= 14.17.0"
+  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:dotnet": "npx projen package:dotnet",
+    "package:go": "npx projen package:go",
     "package:java": "npx projen package:java",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
@@ -38,7 +39,7 @@
     "organization": false
   },
   "devDependencies": {
-    "@cdk8s/projen-common": "^0.0.244",
+    "@cdk8s/projen-common": "^0.0.251",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -137,6 +138,9 @@
       "dotnet": {
         "namespace": "Org.Cdk8s.Grafana",
         "packageId": "Org.Cdk8s.Grafana"
+      },
+      "go": {
+        "moduleName": "github.com/cdk8s-team/cdk8s-grafana-go"
       }
     },
     "tsc": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,10 +291,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cdk8s/projen-common@^0.0.244":
-  version "0.0.244"
-  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.244.tgz#77137906ede358fc54480a31024b885d6e567fed"
-  integrity sha512-0D2Z8bq3W79jXgmyjsEyNS+i5bXR4AoVwWpDwUcNJXopEDdythHQY3N+OaX6aC7+25b/f5hxXqd9POVBl79UOA==
+"@cdk8s/projen-common@^0.0.251":
+  version "0.0.251"
+  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.251.tgz#b0bddd0bbf38c3029167d05ab879e38682434fb5"
+  integrity sha512-Tf717bxiB385r5yuQ6dO0usR1ceebMmE81udvxQ2PwVraKkq1vGVmn6xv+QHraq0yA26P/RB8td3Mi9OB7POxw==
   dependencies:
     codemaker "^1.75.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,10 +291,12 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cdk8s/projen-common@^0.0.237":
-  version "0.0.237"
-  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.237.tgz#44bf86a55b1646b376eed38079541f95558c35f8"
-  integrity sha512-oZjqoiyDSEqak2RrPvKg8bOddhItR9zCw3PwspAZ1ousQ/CM1WvwslatNMcwVAA8cn8TYbDWFB0hbDg5SiPX7Q==
+"@cdk8s/projen-common@^0.0.244":
+  version "0.0.244"
+  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.244.tgz#77137906ede358fc54480a31024b885d6e567fed"
+  integrity sha512-0D2Z8bq3W79jXgmyjsEyNS+i5bXR4AoVwWpDwUcNJXopEDdythHQY3N+OaX6aC7+25b/f5hxXqd9POVBl79UOA==
+  dependencies:
+    codemaker "^1.75.0"
 
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
@@ -1570,6 +1572,15 @@ codemaker@^1.74.0:
   version "1.74.0"
   resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.74.0.tgz#113d679c5f2d6bc6bb04621448930e48cf8cec40"
   integrity sha512-i6fAyWpXAYN/dd8hvzFPJ7+Yb/a23+BmeCu/lPn0KDpDs/KpNKoz/I3Iq9JD4AL9bMc1b7kBeBV+UF6kS6EMEg==
+  dependencies:
+    camelcase "^6.3.0"
+    decamelize "^5.0.1"
+    fs-extra "^10.1.0"
+
+codemaker@^1.75.0:
+  version "1.75.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.75.0.tgz#a54953cf590cb43629c364f62aaf53a7693fc031"
+  integrity sha512-HGZQMJb+IXlGD5MJj6Ae2IXzkd4aoIufj/OfM0HxpJnldWx5rlzBjzgpI+YcK1RdaLm3HWMNDtTLti0qMsHtSA==
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"


### PR DESCRIPTION
The [upgrade-main](https://github.com/cdk8s-team/cdk8s-jenkins/actions/runs/4169133249/jobs/7218914916) workflow is currently failing since we introduced a [new projen project type](https://github.com/cdk8s-team/cdk8s-projen-common/commit/0a1e6a15ab1142a24ff70bf7aa69c3ddcc85acd6) for CDK8s recently. 

Updating here for the workflow to resume. 

Part of https://github.com/cdk8s-team/cdk8s/issues/1185